### PR TITLE
ADR-1642 Bounced email should not be added to set of verified emails

### DIFF
--- a/app/uk/gov/hmrc/alcoholdutycontactpreferences/models/UserAnswers.scala
+++ b/app/uk/gov/hmrc/alcoholdutycontactpreferences/models/UserAnswers.scala
@@ -125,7 +125,8 @@ object UserAnswers {
     clock: Clock
   ): UserAnswers = {
     val existingEmail: Option[SensitiveString] = contactPreferences.emailAddress.map(SensitiveString)
-    val hasVerifiedEmail: Boolean              = existingEmail.nonEmpty && contactPreferences.emailVerificationFlag.contains(true)
+    val hasVerifiedAndValidEmail: Boolean      = existingEmail.nonEmpty &&
+      contactPreferences.emailVerificationFlag.contains(true) && !contactPreferences.bouncedEmailFlag.contains(true)
 
     val correspondenceAddress: String = Seq(
       contactPreferences.addressLine1,
@@ -147,7 +148,7 @@ object UserAnswers {
         SensitiveString(correspondenceAddress)
       ),
       emailAddress = None,
-      verifiedEmailAddresses = if (hasVerifiedEmail) existingEmail.toSet else Set.empty[SensitiveString],
+      verifiedEmailAddresses = if (hasVerifiedAndValidEmail) existingEmail.toSet else Set.empty[SensitiveString],
       startedTime = Instant.now(clock),
       lastUpdated = Instant.now(clock)
     )

--- a/test-utils/helpers/TestData.scala
+++ b/test-utils/helpers/TestData.scala
@@ -131,6 +131,22 @@ trait TestData extends ModelGenerators {
     lastUpdated = Instant.now(clock)
   )
 
+  val emptyUserAnswersBouncedEmail: UserAnswers = UserAnswers(
+    appaId = appaId,
+    userId = userId,
+    subscriptionSummary = SubscriptionSummaryBackend(
+      paperlessReference = false,
+      emailAddress = Some(SensitiveString(emailAddress)),
+      emailVerification = Some(true),
+      bouncedEmail = Some(true),
+      correspondenceAddress = SensitiveString(correspondenceAddress)
+    ),
+    emailAddress = None,
+    verifiedEmailAddresses = Set.empty,
+    startedTime = Instant.now(clock),
+    lastUpdated = Instant.now(clock)
+  )
+
   val getVerificationStatusResponse = GetVerificationStatusResponse(
     List(
       GetVerificationStatusResponseEmailAddressDetails(

--- a/test/uk/gov/hmrc/alcoholdutycontactpreferences/models/UserAnswersSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutycontactpreferences/models/UserAnswersSpec.scala
@@ -111,6 +111,15 @@ class UserAnswersSpec extends SpecBase {
       createdUserAnswers mustBe emptyUserAnswersNoEmail
     }
 
+    "create a UserAnswers from components when the email in the system has bounced" in {
+      val createdUserAnswers = UserAnswers.createUserAnswers(
+        userDetails,
+        contactPreferencesEmailSelected.copy(paperlessReference = false, bouncedEmailFlag = Some(true)),
+        clock
+      )
+      createdUserAnswers mustBe emptyUserAnswersBouncedEmail
+    }
+
     "convert a DecryptedUA to a UserAnswers" in {
       UserAnswers.fromDecryptedUA(decryptedUA) mustBe userAnswers
     }


### PR DESCRIPTION
When creating user answers, also check that bounced indicator is not true before adding an existing verified email to the set of verified emails