### PR TITLE
ADR-2221 Separate country code from rest of address in user answers

### DIFF
--- a/app/uk/gov/hmrc/alcoholdutycontactpreferences/models/UserAnswers.scala
+++ b/app/uk/gov/hmrc/alcoholdutycontactpreferences/models/UserAnswers.scala
@@ -49,7 +49,8 @@ object DecryptedUA {
         userAnswers.subscriptionSummary.emailAddress.map(_.decryptedValue),
         userAnswers.subscriptionSummary.emailVerification,
         userAnswers.subscriptionSummary.bouncedEmail,
-        userAnswers.subscriptionSummary.correspondenceAddress.decryptedValue
+        userAnswers.subscriptionSummary.correspondenceAddress.decryptedValue,
+        userAnswers.subscriptionSummary.countryCode.map(_.decryptedValue)
       ),
       emailAddress = userAnswers.emailAddress.map(_.decryptedValue),
       verifiedEmailAddresses = userAnswers.verifiedEmailAddresses.map(_.decryptedValue),
@@ -133,8 +134,7 @@ object UserAnswers {
       contactPreferences.addressLine2,
       contactPreferences.addressLine3,
       contactPreferences.addressLine4,
-      contactPreferences.postcode,
-      contactPreferences.country
+      contactPreferences.postcode
     ).flatten.mkString("\n")
 
     UserAnswers(
@@ -145,7 +145,8 @@ object UserAnswers {
         existingEmail,
         contactPreferences.emailVerificationFlag,
         contactPreferences.bouncedEmailFlag,
-        SensitiveString(correspondenceAddress)
+        SensitiveString(correspondenceAddress),
+        contactPreferences.country.map(SensitiveString)
       ),
       emailAddress = None,
       verifiedEmailAddresses = if (hasVerifiedAndValidEmail) existingEmail.toSet else Set.empty[SensitiveString],
@@ -163,7 +164,8 @@ object UserAnswers {
         decryptedUA.subscriptionSummary.emailAddress.map(SensitiveString),
         decryptedUA.subscriptionSummary.emailVerification,
         decryptedUA.subscriptionSummary.bouncedEmail,
-        SensitiveString(decryptedUA.subscriptionSummary.correspondenceAddress)
+        SensitiveString(decryptedUA.subscriptionSummary.correspondenceAddress),
+        decryptedUA.subscriptionSummary.countryCode.map(SensitiveString)
       ),
       emailAddress = decryptedUA.emailAddress.map(SensitiveString),
       verifiedEmailAddresses = decryptedUA.verifiedEmailAddresses.map(SensitiveString),
@@ -195,7 +197,8 @@ case class SubscriptionSummary(
   emailAddress: Option[String],
   emailVerification: Option[Boolean],
   bouncedEmail: Option[Boolean],
-  correspondenceAddress: String
+  correspondenceAddress: String,
+  countryCode: Option[String]
 )
 
 object SubscriptionSummary {
@@ -207,7 +210,8 @@ case class SubscriptionSummaryBackend(
   emailAddress: Option[SensitiveString],
   emailVerification: Option[Boolean],
   bouncedEmail: Option[Boolean],
-  correspondenceAddress: SensitiveString
+  correspondenceAddress: SensitiveString,
+  countryCode: Option[SensitiveString]
 )
 
 object SubscriptionSummaryBackend {
@@ -218,7 +222,8 @@ object SubscriptionSummaryBackend {
         (__ \ "emailAddress").formatNullable[SensitiveString] and
         (__ \ "emailVerification").formatNullable[Boolean] and
         (__ \ "bouncedEmail").formatNullable[Boolean] and
-        (__ \ "correspondenceAddress").format[SensitiveString]
+        (__ \ "correspondenceAddress").format[SensitiveString] and
+        (__ \ "countryCode").formatNullable[SensitiveString]
     )(SubscriptionSummaryBackend.apply, unlift(SubscriptionSummaryBackend.unapply))
 
   implicit def sensitiveStringFormat(implicit crypto: Encrypter with Decrypter): Format[SensitiveString] =

--- a/test-utils/helpers/TestData.scala
+++ b/test-utils/helpers/TestData.scala
@@ -36,7 +36,8 @@ trait TestData extends ModelGenerators {
   val credId: String           = "TESTCREDID00000"
 
   val emailAddress          = "john.doe@example.com"
-  val correspondenceAddress = "Flat 123\n1 Example Road\nLondon\nAB1 2CD\nUnited Kingdom"
+  val correspondenceAddress = "Flat 123\n1 Example Road\nLondon\nAB1 2CD"
+  val countryCode           = "GB"
 
   val contactPreferencesEmailSelected: SubscriptionContactPreferences =
     SubscriptionContactPreferences(
@@ -49,7 +50,7 @@ trait TestData extends ModelGenerators {
       addressLine3 = None,
       addressLine4 = Some("London"),
       postcode = Some("AB1 2CD"),
-      country = Some("United Kingdom")
+      country = Some(countryCode)
     )
   val contactPreferencesPostNoEmail: SubscriptionContactPreferences   =
     SubscriptionContactPreferences(
@@ -62,7 +63,7 @@ trait TestData extends ModelGenerators {
       addressLine3 = None,
       addressLine4 = Some("London"),
       postcode = Some("AB1 2CD"),
-      country = Some("United Kingdom")
+      country = Some(countryCode)
     )
 
   val userAnswers: UserAnswers = UserAnswers(
@@ -73,7 +74,8 @@ trait TestData extends ModelGenerators {
       emailAddress = Some(SensitiveString(emailAddress)),
       emailVerification = Some(true),
       bouncedEmail = Some(false),
-      correspondenceAddress = SensitiveString(correspondenceAddress)
+      correspondenceAddress = SensitiveString(correspondenceAddress),
+      countryCode = Some(SensitiveString(countryCode))
     ),
     emailAddress = Some(SensitiveString(emailAddress)),
     verifiedEmailAddresses = Set(SensitiveString(emailAddress)),
@@ -90,7 +92,8 @@ trait TestData extends ModelGenerators {
       emailAddress = Some(emailAddress),
       emailVerification = Some(true),
       bouncedEmail = Some(false),
-      correspondenceAddress = correspondenceAddress
+      correspondenceAddress = correspondenceAddress,
+      countryCode = Some(countryCode)
     ),
     emailAddress = Some(emailAddress),
     verifiedEmailAddresses = Set(emailAddress),
@@ -107,7 +110,8 @@ trait TestData extends ModelGenerators {
       emailAddress = Some(SensitiveString(emailAddress)),
       emailVerification = Some(true),
       bouncedEmail = Some(false),
-      correspondenceAddress = SensitiveString(correspondenceAddress)
+      correspondenceAddress = SensitiveString(correspondenceAddress),
+      countryCode = Some(SensitiveString(countryCode))
     ),
     emailAddress = None,
     verifiedEmailAddresses = Set(SensitiveString(emailAddress)),
@@ -123,7 +127,8 @@ trait TestData extends ModelGenerators {
       emailAddress = None,
       emailVerification = None,
       bouncedEmail = None,
-      correspondenceAddress = SensitiveString(correspondenceAddress)
+      correspondenceAddress = SensitiveString(correspondenceAddress),
+      countryCode = Some(SensitiveString(countryCode))
     ),
     emailAddress = None,
     verifiedEmailAddresses = Set.empty,
@@ -139,7 +144,8 @@ trait TestData extends ModelGenerators {
       emailAddress = Some(SensitiveString(emailAddress)),
       emailVerification = Some(true),
       bouncedEmail = Some(true),
-      correspondenceAddress = SensitiveString(correspondenceAddress)
+      correspondenceAddress = SensitiveString(correspondenceAddress),
+      countryCode = Some(SensitiveString(countryCode))
     ),
     emailAddress = None,
     verifiedEmailAddresses = Set.empty,

--- a/test/uk/gov/hmrc/alcoholdutycontactpreferences/models/UserAnswersSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutycontactpreferences/models/UserAnswersSpec.scala
@@ -36,7 +36,7 @@ class UserAnswersSpec extends SpecBase {
   "UserAnswers must" - {
     "when encryption is enabled" - {
       val jsonWithEncrpytion =
-        s"""{"_id":"$appaId","userId":"$userId","subscriptionSummary":{"paperlessReference":true,"emailAddress":"QuEpxLZgVPo2eQybYbl9Yxq+hGWotDBesA31u/dlBBU=","emailVerification":true,"bouncedEmail":false,"correspondenceAddress":"dL4kJMiwICXDMg/IDWlMa9sQF+RyJnds9bhhgmdV3TeyHLvl5IP0zVNbubW8bu22+JHyyNxBAWDINhL+PKgeUQ=="},"emailAddress":"QuEpxLZgVPo2eQybYbl9Yxq+hGWotDBesA31u/dlBBU=","verifiedEmailAddresses":["QuEpxLZgVPo2eQybYbl9Yxq+hGWotDBesA31u/dlBBU="],"data":{"contactPreferenceEmail":true},"startedTime":{"$$date":{"$$numberLong":"1718118467838"}},"lastUpdated":{"$$date":{"$$numberLong":"1718118467838"}},"validUntil":{"$$date":{"$$numberLong":"1718118467839"}}}"""
+        s"""{"_id":"$appaId","userId":"$userId","subscriptionSummary":{"paperlessReference":true,"emailAddress":"QuEpxLZgVPo2eQybYbl9Yxq+hGWotDBesA31u/dlBBU=","emailVerification":true,"bouncedEmail":false,"correspondenceAddress":"dL4kJMiwICXDMg/IDWlMa9sQF+RyJnds9bhhgmdV3Tdet8rzpkdptCfRf5gLxSH8","countryCode":"XYlyMMmfKtRG++9BeQ3mmQ=="},"emailAddress":"QuEpxLZgVPo2eQybYbl9Yxq+hGWotDBesA31u/dlBBU=","verifiedEmailAddresses":["QuEpxLZgVPo2eQybYbl9Yxq+hGWotDBesA31u/dlBBU="],"data":{"contactPreferenceEmail":true},"startedTime":{"$$date":{"$$numberLong":"1718118467838"}},"lastUpdated":{"$$date":{"$$numberLong":"1718118467838"}},"validUntil":{"$$date":{"$$numberLong":"1718118467839"}}}"""
 
       implicit val crypto: Encrypter with Decrypter = SymmetricCryptoFactory.aesCrypto(appConfig.cryptoKey)
 
@@ -50,7 +50,7 @@ class UserAnswersSpec extends SpecBase {
 
     "when encryption is disabled" - {
       val jsonWithoutEncryption =
-        s"""{"_id":"$appaId","userId":"$userId","subscriptionSummary":{"paperlessReference":true,"emailAddress":"\\"john.doe@example.com\\"","emailVerification":true,"bouncedEmail":false,"correspondenceAddress":"\\"Flat 123\\\\n1 Example Road\\\\nLondon\\\\nAB1 2CD\\\\nUnited Kingdom\\""},"emailAddress":"\\"john.doe@example.com\\"","verifiedEmailAddresses":["\\"john.doe@example.com\\""],"data":{"contactPreferenceEmail":true},"startedTime":{"$$date":{"$$numberLong":"1718118467838"}},"lastUpdated":{"$$date":{"$$numberLong":"1718118467838"}},"validUntil":{"$$date":{"$$numberLong":"1718118467839"}}}"""
+        s"""{"_id":"$appaId","userId":"$userId","subscriptionSummary":{"paperlessReference":true,"emailAddress":"\\"john.doe@example.com\\"","emailVerification":true,"bouncedEmail":false,"correspondenceAddress":"\\"Flat 123\\\\n1 Example Road\\\\nLondon\\\\nAB1 2CD\\"","countryCode":"\\"GB\\""},"emailAddress":"\\"john.doe@example.com\\"","verifiedEmailAddresses":["\\"john.doe@example.com\\""],"data":{"contactPreferenceEmail":true},"startedTime":{"$$date":{"$$numberLong":"1718118467838"}},"lastUpdated":{"$$date":{"$$numberLong":"1718118467838"}},"validUntil":{"$$date":{"$$numberLong":"1718118467839"}}}"""
 
       implicit val crypto: Encrypter with Decrypter = NoCrypto
 
@@ -127,7 +127,7 @@ class UserAnswersSpec extends SpecBase {
 
   "DecryptedUA must" - {
     val json =
-      s"""{"appaId":"$appaId","userId":"$userId","subscriptionSummary":{"paperlessReference":true,"emailAddress":"john.doe@example.com","emailVerification":true,"bouncedEmail":false,"correspondenceAddress":"Flat 123\\n1 Example Road\\nLondon\\nAB1 2CD\\nUnited Kingdom"},"emailAddress":"john.doe@example.com","verifiedEmailAddresses":["john.doe@example.com"],"data":{"contactPreferenceEmail":true},"startedTime":{"$$date":{"$$numberLong":"1718118467838"}},"lastUpdated":{"$$date":{"$$numberLong":"1718118467838"}},"validUntil":{"$$date":{"$$numberLong":"1718118467839"}}}"""
+      s"""{"appaId":"$appaId","userId":"$userId","subscriptionSummary":{"paperlessReference":true,"emailAddress":"john.doe@example.com","emailVerification":true,"bouncedEmail":false,"correspondenceAddress":"Flat 123\\n1 Example Road\\nLondon\\nAB1 2CD","countryCode":"GB"},"emailAddress":"john.doe@example.com","verifiedEmailAddresses":["john.doe@example.com"],"data":{"contactPreferenceEmail":true},"startedTime":{"$$date":{"$$numberLong":"1718118467838"}},"lastUpdated":{"$$date":{"$$numberLong":"1718118467838"}},"validUntil":{"$$date":{"$$numberLong":"1718118467839"}}}"""
 
     "serialise to json" in {
       Json.toJson(uaDecrypted).toString() mustBe json


### PR DESCRIPTION
Since country code will be used to look up the country name in the frontend, it must be cached separately from the rest of the correspondence address, which is a single string with newline characters